### PR TITLE
Gl/tov eq

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,7 @@
 
 ```@autodocs
 Modules = [
+  QSpin.PhysicalConstants,
   QSpin.Parameters,
   QSpin.Grids,
   QSpin.Hamiltonian,

--- a/scripts/PhysConsts.jl
+++ b/scripts/PhysConsts.jl
@@ -1,0 +1,11 @@
+# Physical constants in SI units
+PhysConst = (
+    ħ = 1.0545718 * 1e-34, # m^2*kg / s
+    Msun = 1.9891 * 1e30,      # kg
+    c = 299792458,         # m / s
+    G = 6.67408 * 1e-11,   # m^3 / (kg * s^2)
+    kpc = 3.08567758 * 1e19, # m
+    eV = 1.782662 * 1e-36,  # kg
+    Gyear = 31556926 * 1e9,   # s
+    mn = 1.674927471 * 1e-27, # kg
+)

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -1,0 +1,104 @@
+using QSpin
+using QSpin.Parameters: ParameterType
+using Plots, LaTeXStrings
+
+# Physical constants in SI units
+PhysConst = (
+    ħ = 1.0545718 * 1e-34, # m^2*kg / s
+    Msun = 1.9891 * 1e30,      # kg
+    c = 299792458,         # m / s
+    G = 6.67408 * 1e-11,   # m^3 / (kg * s^2)
+    kpc = 3.08567758 * 1e19, # m
+    eV = 1.782662 * 1e-36,  # kg
+    Gyear = 31556926 * 1e9,   # s
+    mn = 1.674927471 * 1e-27, # kg
+)
+
+# Polytropic EoS parameters
+EoS_Param = (
+    γcore = 5/2.0, # Polytropic index for the core
+    ρb = 3e14*1e3, # Transition density between crust and core in kg/m^3
+)
+
+# Simulation Input Parameters
+Sim_Input = (
+    ρ0 = 1e15*1e3, # Initial central density in kg/m^3 !! CHECKING UNITS
+    dr = 0.01*1e3, # Radial step in meters
+    Dr = 0.1*1e3, # Radial interval for recording values in meters
+    r_end = 15e3, # Maximum radius to solve up to in meters
+);
+# Polytropic EoS for P-ρ relation
+function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
+    Kcrust = (3*π^2)^(2/3) * PhysConst.ħ^2 / (5*PhysConst.mn^(8/3)); # Crust EoS constant
+    γcrust = 5/3; # Crust EoS polytropic
+    Kcore = Kcrust * EoS_Param.ρb^(γcrust-EoS_Param.γcore); # Core EoS constant to ensure continuity at ρb
+    function EoS_P(ρ::Float64)
+        if ρ < 0
+            P = 0.0; # Ensure non-negative pressure
+        elseif ρ <= EoS_Param.ρb
+            P = Kcrust * ρ^γcrust;
+        else
+            P = Kcore * ρ^EoS_Param.γcore;
+        end
+        return P;
+    end
+    Pb = EoS_P(EoS_Param.ρb); # Pressure at the crust-core transition for continuity check
+    println("Pressure at crust-core transition (Pb): ", Pb)
+    function EoS_Inv(P::Float64)
+        if P < 0
+            ρ = 0.0; # Ensure non-negative density
+        elseif P <= Pb
+            ρ = (P / Kcrust)^(1/γcrust);
+        else
+            ρ = (P / Kcore)^(1/EoS_Param.γcore);
+        end
+        return ρ
+    end
+
+    return EoS_P, EoS_Inv
+end
+
+# ToV equation setup
+function TOV_Eq(Eos_inv::Function, PhysConst::ParameterType)
+    function tov_eq(u::AbstractArray, r::Float64)
+        P = u[1];
+        m = u[2];
+        ρ = EoS_inv(P);
+        if r == 0.0
+            dPdr = 0;
+        else
+            dPdr =
+                -PhysConst.G / r^2 * (ρ + P/PhysConst.c^2) * (m + 4*π*r^3*P/PhysConst.c^2) /
+                (1 - 2*PhysConst.G*m/(r*PhysConst.c^2));
+        end
+        dmdr = 4*π*r^2*ρ;
+        return [dPdr; dmdr]
+    end
+    return tov_eq
+end
+
+# Fucntion Setup for inverse EoS and TOV equation for the solver
+EoS, EoS_inv = EoS_Func(EoS_Param, PhysConst);
+TOV = TOV_Eq(EoS_inv, PhysConst);
+
+# Setting up initial condition accordingly to the EoS for a given central density ρ0.
+P0 = EoS(Sim_Input.ρ0); # Initial central pressure from EoS
+m0 = 0.0; # Initial enclosed mass at the center
+u0 = [P0; m0]; # Initial conditions: central pressure and enclosed mass
+
+# Sovling the TOV equation using the RK4 method with QSpin OdeSolve module
+@time ur, r =
+    QSpin.OdeSolve.evolve_rk4(u0, Sim_Input.dr, Sim_Input.Dr, Sim_Input.r_end, TOV);
+
+# Plotting
+Pc = EoS(Sim_Input.ρ0) # Check continuity at crust-core transition
+plot!(
+    r/1e3,
+    ur[1, :]/Pc,
+    label = string(L"\gamma_{core}=", EoS_Param.γcore),
+    xlabel = "Radius (km)",
+    ylabel = L"P/P_c",
+    title = string("TOV Solution for ", L"ρ_{c}=", Sim_Input.ρ0, L"\textrm{kg/m}^3"),
+    xticks = range(0.0, stop = 15.0, length = 7),
+    yticks = range(0.0, stop = 1.0, length = 6),
+)

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -1,12 +1,11 @@
 using QSpin
 using QSpin.Parameters: ParameterType
+using QSpin.PhysicalConstants
 using Plots, LaTeXStrings
 # This script is demonstrating how to solve the Tolman–Oppenheimer–Volkoff (TOV) equation for neutron stars using the QSpin package with the built-in TOV solver using Runge-Kutta 4th order method.
 # The parameters are chosen from https://github.com/vanessagraber/teaching_materials/blob/master/summerschool_CRAQ_2019/mass_radius_relations.ipynb.
-
-
-include("PhysConsts.jl")
-
+ħ = hbar;
+mn = neutron_mass;
 # Polytropic EoS parameters
 EoS_Param_Stiff = (
     γcore = 3.0, # Polytropic index for the core
@@ -38,8 +37,8 @@ Set up the EoS functions for a given set of parameters and physical constants.
 # A polytropic EoS is used in this script according to https://github.com/vanessagraber/teaching_materials/blob/master/summerschool_CRAQ_2019/mass_radius_relations.ipynb.
 
 """
-function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
-    Kcrust = (3*π^2)^(2/3) * PhysConst.ħ^2 / (5*PhysConst.mn^(8/3)); # Crust EoS constant
+function EoS_Func(EoS_Param::ParameterType)
+    Kcrust = (3*π^2)^(2/3) * ħ^2 / (5*mn^(8/3)); # Crust EoS constant
     γcrust = 5/3; # Crust EoS polytropic
     Kcore = Kcrust * EoS_Param.ρb^(γcrust-EoS_Param.γcore); # Core EoS constant to ensure continuity at ρb
 
@@ -88,8 +87,8 @@ function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
 end
 
 # Fucntion Setup for inverse EoS and TOV equation for the solver
-EoS_Stiff, EoS_inv_Stiff = EoS_Func(EoS_Param_Stiff, PhysConst);
-EoS_Soft, EoS_inv_Soft = EoS_Func(EoS_Param_Soft, PhysConst);
+EoS_Stiff, EoS_inv_Stiff = EoS_Func(EoS_Param_Stiff);
+EoS_Soft, EoS_inv_Soft = EoS_Func(EoS_Param_Soft);
 
 # Setting up initial condition accordingly to the EoS for a given central density ρ0.
 u0_Stiff = [EoS_Stiff(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure and enclosed mass
@@ -102,7 +101,6 @@ u0_Soft = [EoS_Soft(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure
     Sim_Input.Dr,
     Sim_Input.r_end,
     EoS_inv_Stiff,
-    PhysConst,
 );
 
 @time Pr_Soft, mr_Soft, ρr_Soft, M_Soft, R_Soft = QSpin.OdeSolve.TOV_Solve_rk4(
@@ -111,7 +109,6 @@ u0_Soft = [EoS_Soft(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure
     Sim_Input.Dr,
     Sim_Input.r_end,
     EoS_inv_Soft,
-    PhysConst,
 );
 
 # Computing the M-R relation by varying the central density and solving the TOV equation for each case. The radius is defined by the first point that the pressure becomes negative.
@@ -129,7 +126,6 @@ for cc = 1:length(ρc_scan)
         Sim_Input.Dr,
         Sim_Input.r_end,
         EoS_inv_Stiff,
-        PhysConst,
     );
     M_StiffScan[Int.(cc)] = M
     R_StiffScan[Int.(cc)] = R
@@ -140,7 +136,6 @@ for cc = 1:length(ρc_scan)
         Sim_Input.Dr,
         Sim_Input.r_end,
         EoS_inv_Soft,
-        PhysConst,
     );
     M_SoftScan[Int.(cc)] = M
     R_SoftScan[Int.(cc)] = R
@@ -164,7 +159,7 @@ plot(
     ),
     plot(
         r/1e3,
-        [mr_Stiff mr_Soft]/PhysConst.Msun,
+        [mr_Stiff mr_Soft]/mass_sun,
         label = [string(L"\gamma_\mathrm{core}=", EoS_Param_Stiff.γcore) string(
             L"\gamma_\mathrm{core}=",
             EoS_Param_Soft.γcore,
@@ -188,9 +183,10 @@ plot(
     ),
     scatter(
         [R_StiffScan R_SoftScan]/1e3,
-        [M_StiffScan M_SoftScan]/PhysConst.Msun;
+        [M_StiffScan M_SoftScan]/mass_sun;
         zcolor = log.([ρc_scan ρc_scan])/log(10), # color the data by the core density
         markershape = [:circle :diamond],
+        bg = :linen,
         markersize = [2 2],
         label = ["Stiff" "Soft"],
         xlabel = "Radius (km)",

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -1,7 +1,6 @@
 using QSpin
 using QSpin.Parameters: ParameterType
 using Plots, LaTeXStrings
-
 # Physical constants in SI units
 PhysConst = (
     ħ = 1.0545718 * 1e-34, # m^2*kg / s
@@ -72,39 +71,8 @@ function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
     return EoS_P, EoS_Inv
 end
 
-"""
-Set up the TOV equation for a given inverse EoS function and physical constants.
-
-# Arguments
-- `EoS_inv::Function`: The inverse EoS function that gives density as
-- 'u::AbstractArray': The current state of the system, where u[1] is pressure P and u[2] is enclosed mass m.
--'r::Float64': The current radius at which the TOV equation is being evaluated.
-
-# Returns
-- `tov_eq::Function`: A function of [dP/dr; dm/dr] for the TOV equation.
-
-"""
-function TOV_Eq(Eos_inv::Function, PhysConst::ParameterType)
-    function tov_eq(u::AbstractArray, r::Float64)
-        P = u[1];
-        m = u[2];
-        ρ = EoS_inv(P);
-        if r == 0.0
-            dPdr = 0;
-        else
-            dPdr =
-                -PhysConst.G / r^2 * (ρ + P/PhysConst.c^2) * (m + 4*π*r^3*P/PhysConst.c^2) /
-                (1 - 2*PhysConst.G*m/(r*PhysConst.c^2));
-        end
-        dmdr = 4*π*r^2*ρ;
-        return [dPdr; dmdr]
-    end
-    return tov_eq
-end
-
 # Fucntion Setup for inverse EoS and TOV equation for the solver
 EoS, EoS_inv = EoS_Func(EoS_Param, PhysConst);
-TOV = TOV_Eq(EoS_inv, PhysConst);
 
 # Setting up initial condition accordingly to the EoS for a given central density ρ0.
 P0 = EoS(Sim_Input.ρ0); # Initial central pressure from EoS
@@ -112,17 +80,14 @@ m0 = 0.0; # Initial enclosed mass at the center
 u0 = [P0; m0]; # Initial conditions: central pressure and enclosed mass
 
 # Sovling the TOV equation using the RK4 method with QSpin OdeSolve module
-@time ur, r =
-    QSpin.OdeSolve.evolve_rk4(u0, Sim_Input.dr, Sim_Input.Dr, Sim_Input.r_end, TOV);
-ρr = zeros(size(r))
-for rr = 1:length(r)
-    ρr[rr] = EoS_inv(ur[1, rr]) # Density profile from the inverse EoS
-end
+@time Pr, mr, ρr, r =
+    QSpin.OdeSolve.TOV_Solve_rk4(u0, Sim_Input.dr, Sim_Input.Dr, Sim_Input.r_end, EoS_inv);
+
 # Plotting
 Pc = EoS(Sim_Input.ρ0) # Check continuity at crust-core transition
 plot!(
     r/1e3,
-    ur[1, :]/Pc,
+    Pr/Pc,
     label = string(L"\gamma_{core}=", EoS_Param.γcore),
     xlabel = "Radius (km)",
     ylabel = L"P/P_c",

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -15,10 +15,10 @@ EoS_Param_Soft = (
 )
 # Simulation Input Parameters
 Sim_Input = (
-    ρ0 = 1e15*1e3, # Initial central density in kg/m^3 !! CHECKING UNITS
+    ρ0 = 1e15*1e3, # Initial central density in kg/m^3 (1e15 g/cm^3)
     dr = 0.01*1e3, # Radial step in meters
-    Dr = 0.1*1e3, # Radial interval for recording values in meters
-    r_end = 15e3, # Maximum radius to solve up to in meters
+    Dr = 0.05*1e3, # Radial interval for recording values in meters
+    r_end = 20e3, # Maximum radius to solve up to in meters
 );
 
 """
@@ -93,7 +93,7 @@ u0_Stiff = [EoS_Stiff(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressu
 u0_Soft = [EoS_Soft(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure and enclosed mass
 
 # Sovling the TOV equation using the RK4 method with QSpin OdeSolve module
-@time Pr_Stiff, mr_Stiff, ρr_Stiff, r = QSpin.OdeSolve.TOV_Solve_rk4(
+@time Pr_Stiff, mr_Stiff, ρr_Stiff, M_Stiff, R_Stiff, r = QSpin.OdeSolve.TOV_Solve_rk4(
     u0_Stiff,
     Sim_Input.dr,
     Sim_Input.Dr,
@@ -102,7 +102,7 @@ u0_Soft = [EoS_Soft(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure
     PhysConst,
 );
 
-@time Pr_Soft, mr_Soft, ρr_Soft = QSpin.OdeSolve.TOV_Solve_rk4(
+@time Pr_Soft, mr_Soft, ρr_Soft, M_Soft, R_Soft = QSpin.OdeSolve.TOV_Solve_rk4(
     u0_Soft,
     Sim_Input.dr,
     Sim_Input.Dr,
@@ -115,6 +115,39 @@ u0_Soft = [EoS_Soft(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure
 Pc_Stiff = EoS_Stiff(Sim_Input.ρ0) # Check continuity at crust-core transition
 Pc_Soft = EoS_Soft(Sim_Input.ρ0) # Check continuity at crust-core transition
 
+ρc_scan = exp10.(range(17.5, stop = 20, length = 150))
+
+
+M_StiffScan = zeros(length(ρc_scan));
+R_StiffScan = zeros(length(ρc_scan));
+M_SoftScan = zeros(length(ρc_scan));
+R_SoftScan = zeros(length(ρc_scan));
+for cc = 1:length(ρc_scan)
+    println(cc)
+    ρc = ρc_scan[Int.(cc)];
+
+    Pr, mr, ρr, M, R = QSpin.OdeSolve.TOV_Solve_rk4(
+        [EoS_Stiff(ρc); 0.0],
+        Sim_Input.dr,
+        Sim_Input.Dr,
+        Sim_Input.r_end,
+        EoS_inv_Stiff,
+        PhysConst,
+    );
+    M_StiffScan[Int.(cc)] = M
+    R_StiffScan[Int.(cc)] = R
+    # println("Mass: ", M/PhysConst.Msun, " M_sun, Radius: ", R/1e3, " km")
+    Pr, mr, ρr, M, R = QSpin.OdeSolve.TOV_Solve_rk4(
+        [EoS_Soft(ρc); 0.0],
+        Sim_Input.dr,
+        Sim_Input.Dr,
+        Sim_Input.r_end,
+        EoS_inv_Soft,
+        PhysConst,
+    );
+    M_SoftScan[Int.(cc)] = M
+    R_SoftScan[Int.(cc)] = R
+end
 
 plot(
     plot(
@@ -127,6 +160,7 @@ plot(
         xlabel = "Radius (km)",
         ylabel = L"P/P_c",
         framestyle = :box,
+        linewidth = 2,
     ),
     plot(
         r/1e3,
@@ -138,18 +172,30 @@ plot(
         xlabel = "Radius (m)",
         ylabel = L"m/M_\odot",
         framestyle = :box,
+        inewidth = 2,
     ),
     plot(
         r/1e3,
-        [ρr_Stiff ρr_Soft],
+        [ρr_Stiff ρr_Soft]/1e18,
         label = [string(L"\gamma_{core}=", EoS_Param_Stiff.γcore) string(
             L"\gamma_{core}=",
             EoS_Param_Soft.γcore,
         )],
         xlabel = "Radius (m)",
-        ylabel = L"\rho\;(\textrm{kg/m}^3)",
+        ylabel = L"\rho\;(\times10^{18}\;\textrm{kg/m}^3)",
         framestyle = :box,
+        linewidth = 2,
     ),
-    layout = (1, 3),
+    plot(
+        [R_SoftScan R_StiffScan]/1e3,
+        [M_SoftScan M_StiffScan]/PhysConst.Msun,
+        seriestype = :scatter,
+        label = ["Stiff" "Soft"],
+        xlabel = "Radius (km)",
+        ylabel = L"\textrm{Mass }(M_\odot)",
+        framestyle = :box,
+        linewidth = 2,
+    ),
+    layout = (2, 2),
 )
 #plot!(size=(800,400))

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -1,6 +1,9 @@
 using QSpin
 using QSpin.Parameters: ParameterType
 using Plots, LaTeXStrings
+# This script is demonstrating how to solve the Tolman–Oppenheimer–Volkoff (TOV) equation for neutron stars using the QSpin package with the built-in TOV solver using Runge-Kutta 4th order method.
+# The parameters are chosen from https://github.com/vanessagraber/teaching_materials/blob/master/summerschool_CRAQ_2019/mass_radius_relations.ipynb.
+
 
 include("PhysConsts.jl")
 
@@ -17,7 +20,7 @@ EoS_Param_Soft = (
 Sim_Input = (
     ρ0 = 1e15*1e3, # Initial central density in kg/m^3 (1e15 g/cm^3)
     dr = 0.01*1e3, # Radial step in meters
-    Dr = 0.05*1e3, # Radial interval for recording values in meters
+    Dr = 0.01*1e3, # Radial interval for recording values in meters
     r_end = 20e3, # Maximum radius to solve up to in meters
 );
 
@@ -123,7 +126,6 @@ R_StiffScan = zeros(length(ρc_scan));
 M_SoftScan = zeros(length(ρc_scan));
 R_SoftScan = zeros(length(ρc_scan));
 for cc = 1:length(ρc_scan)
-    println(cc)
     ρc = ρc_scan[Int.(cc)];
 
     Pr, mr, ρr, M, R = QSpin.OdeSolve.TOV_Solve_rk4(
@@ -153,8 +155,8 @@ plot(
     plot(
         r/1e3,
         [Pr_Stiff/Pc_Stiff Pr_Soft/Pc_Soft],
-        label = [string(L"\gamma_{core}=", EoS_Param_Stiff.γcore) string(
-            L"\gamma_{core}=",
+        label = [string(L"\gamma_\mathrm{core}=", EoS_Param_Stiff.γcore) string(
+            L"\gamma_\mathrm{core}=",
             EoS_Param_Soft.γcore,
         )],
         xlabel = "Radius (km)",
@@ -165,20 +167,20 @@ plot(
     plot(
         r/1e3,
         [mr_Stiff mr_Soft]/PhysConst.Msun,
-        label = [string(L"\gamma_{core}=", EoS_Param_Stiff.γcore) string(
-            L"\gamma_{core}=",
+        label = [string(L"\gamma_\mathrm{core}=", EoS_Param_Stiff.γcore) string(
+            L"\gamma_\mathrm{core}=",
             EoS_Param_Soft.γcore,
         )],
         xlabel = "Radius (m)",
         ylabel = L"m/M_\odot",
         framestyle = :box,
-        inewidth = 2,
+        linewidth = 2,
     ),
     plot(
         r/1e3,
         [ρr_Stiff ρr_Soft]/1e18,
-        label = [string(L"\gamma_{core}=", EoS_Param_Stiff.γcore) string(
-            L"\gamma_{core}=",
+        label = [string(L"\gamma_\mathrm{core}=", EoS_Param_Stiff.γcore) string(
+            L"\gamma_\mathrm{core}=",
             EoS_Param_Soft.γcore,
         )],
         xlabel = "Radius (m)",
@@ -186,13 +188,15 @@ plot(
         framestyle = :box,
         linewidth = 2,
     ),
-    plot(
-        [R_SoftScan R_StiffScan]/1e3,
-        [M_SoftScan M_StiffScan]/PhysConst.Msun,
-        seriestype = :scatter,
+    scatter(
+        [R_StiffScan R_SoftScan]/1e3,
+        [M_StiffScan M_SoftScan]/PhysConst.Msun;
+        zcolor = log.([ρc_scan ρc_scan])/log(10), # color the data by the core density
+        markershape = [:circle :diamond],
+        markersize = [2 2],
         label = ["Stiff" "Soft"],
         xlabel = "Radius (km)",
-        ylabel = L"\textrm{Mass }(M_\odot)",
+        ylabel = L"\textrm{Mass}\;(M_\odot)",
         framestyle = :box,
         linewidth = 2,
     ),

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -1,17 +1,8 @@
 using QSpin
 using QSpin.Parameters: ParameterType
 using Plots, LaTeXStrings
-# Physical constants in SI units
-PhysConst = (
-    ħ = 1.0545718 * 1e-34, # m^2*kg / s
-    Msun = 1.9891 * 1e30,      # kg
-    c = 299792458,         # m / s
-    G = 6.67408 * 1e-11,   # m^3 / (kg * s^2)
-    kpc = 3.08567758 * 1e19, # m
-    eV = 1.782662 * 1e-36,  # kg
-    Gyear = 31556926 * 1e9,   # s
-    mn = 1.674927471 * 1e-27, # kg
-)
+
+include("PhysConsts.jl")
 
 # Polytropic EoS parameters
 EoS_Param = (
@@ -45,6 +36,16 @@ function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
     Kcrust = (3*π^2)^(2/3) * PhysConst.ħ^2 / (5*PhysConst.mn^(8/3)); # Crust EoS constant
     γcrust = 5/3; # Crust EoS polytropic
     Kcore = Kcrust * EoS_Param.ρb^(γcrust-EoS_Param.γcore); # Core EoS constant to ensure continuity at ρb
+
+    """
+    Define the EoS function giving the P-ρ relation.
+
+    # Arguments
+    - `ρ::Union{Float64,AbstractArray,Array{Float64},Vector{Float64}}`: The density or array of densities for which to compute the pressure.
+
+    # Returns
+    - `P::Union{Float64,AbstractArray,Array{Float64},Vector{Float64}}`: The corresponding pressure or array of pressures computed from the EoS.
+    """
     function EoS_P(ρ::Union{Float64,AbstractArray,Array{Float64},Vector{Float64}})
         if ρ < 0
             P = 0.0; # Ensure non-negative pressure
@@ -57,6 +58,15 @@ function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
     end
     Pb = EoS_P(EoS_Param.ρb); # Pressure at the crust-core transition for continuity check
     println("Pressure at crust-core transition (Pb): ", Pb)
+
+    """
+    Define the inverse EoS function giving the ρ-P relation.
+    # Arguments
+    - `P::Union{Float64,AbstractArray,Array{Float64},Vector{Float64}}`: The pressure or array of pressures for which to compute the density.
+
+    # Returns
+    - `ρ::Union{Float64,AbstractArray,Array{Float64},Vector{Float64}}`: The corresponding density or array of densities computed from the EoS.
+    """
     function EoS_Inv(P::Union{Float64,AbstractArray,Array{Float64},Vector{Float64}})
         if P < 0
             ρ = 0.0; # Ensure non-negative density
@@ -80,8 +90,14 @@ m0 = 0.0; # Initial enclosed mass at the center
 u0 = [P0; m0]; # Initial conditions: central pressure and enclosed mass
 
 # Sovling the TOV equation using the RK4 method with QSpin OdeSolve module
-@time Pr, mr, ρr, r =
-    QSpin.OdeSolve.TOV_Solve_rk4(u0, Sim_Input.dr, Sim_Input.Dr, Sim_Input.r_end, EoS_inv);
+@time Pr, mr, ρr, r = QSpin.OdeSolve.TOV_Solve_rk4(
+    u0,
+    Sim_Input.dr,
+    Sim_Input.Dr,
+    Sim_Input.r_end,
+    EoS_inv,
+    PhysConst,
+);
 
 # Plotting
 Pc = EoS(Sim_Input.ρ0) # Check continuity at crust-core transition

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -27,30 +27,44 @@ Sim_Input = (
     Dr = 0.1*1e3, # Radial interval for recording values in meters
     r_end = 15e3, # Maximum radius to solve up to in meters
 );
-# Polytropic EoS for P-ρ relation
+
+"""
+Set up the EoS functions for a given set of parameters and physical constants.
+
+# Arguments
+- `EoS_Param::ParameterType`: The parameters for the polytropic EoS.
+- `PhysConst::ParameterType`: The physical constants in SI units.
+
+# Returns
+- `EoS_P::Function`: The EoS function that gives pressure as a function of density.
+- `EoS_Inv::Function`: The inverse EoS function that gives density as a function of pressure.
+
+# A polytropic EoS is used in this script.
+
+"""
 function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
     Kcrust = (3*π^2)^(2/3) * PhysConst.ħ^2 / (5*PhysConst.mn^(8/3)); # Crust EoS constant
     γcrust = 5/3; # Crust EoS polytropic
     Kcore = Kcrust * EoS_Param.ρb^(γcrust-EoS_Param.γcore); # Core EoS constant to ensure continuity at ρb
-    function EoS_P(ρ::Float64)
+    function EoS_P(ρ::Union{Float64,AbstractArray,Array{Float64},Vector{Float64}})
         if ρ < 0
             P = 0.0; # Ensure non-negative pressure
         elseif ρ <= EoS_Param.ρb
-            P = Kcrust * ρ^γcrust;
+            P = Kcrust * ρ .^ γcrust;
         else
-            P = Kcore * ρ^EoS_Param.γcore;
+            P = Kcore * ρ .^ EoS_Param.γcore;
         end
         return P;
     end
     Pb = EoS_P(EoS_Param.ρb); # Pressure at the crust-core transition for continuity check
     println("Pressure at crust-core transition (Pb): ", Pb)
-    function EoS_Inv(P::Float64)
+    function EoS_Inv(P::Union{Float64,AbstractArray,Array{Float64},Vector{Float64}})
         if P < 0
             ρ = 0.0; # Ensure non-negative density
         elseif P <= Pb
-            ρ = (P / Kcrust)^(1/γcrust);
+            ρ = (P / Kcrust) .^ (1/γcrust);
         else
-            ρ = (P / Kcore)^(1/EoS_Param.γcore);
+            ρ = (P / Kcore) .^ (1/EoS_Param.γcore);
         end
         return ρ
     end
@@ -58,7 +72,18 @@ function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
     return EoS_P, EoS_Inv
 end
 
-# ToV equation setup
+"""
+Set up the TOV equation for a given inverse EoS function and physical constants.
+
+# Arguments
+- `EoS_inv::Function`: The inverse EoS function that gives density as
+- 'u::AbstractArray': The current state of the system, where u[1] is pressure P and u[2] is enclosed mass m.
+-'r::Float64': The current radius at which the TOV equation is being evaluated.
+
+# Returns
+- `tov_eq::Function`: A function of [dP/dr; dm/dr] for the TOV equation.
+
+"""
 function TOV_Eq(Eos_inv::Function, PhysConst::ParameterType)
     function tov_eq(u::AbstractArray, r::Float64)
         P = u[1];
@@ -89,7 +114,10 @@ u0 = [P0; m0]; # Initial conditions: central pressure and enclosed mass
 # Sovling the TOV equation using the RK4 method with QSpin OdeSolve module
 @time ur, r =
     QSpin.OdeSolve.evolve_rk4(u0, Sim_Input.dr, Sim_Input.Dr, Sim_Input.r_end, TOV);
-
+ρr = zeros(size(r))
+for rr = 1:length(r)
+    ρr[rr] = EoS_inv(ur[1, rr]) # Density profile from the inverse EoS
+end
 # Plotting
 Pc = EoS(Sim_Input.ρ0) # Check continuity at crust-core transition
 plot!(

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -5,11 +5,14 @@ using Plots, LaTeXStrings
 include("PhysConsts.jl")
 
 # Polytropic EoS parameters
-EoS_Param = (
-    γcore = 5/2.0, # Polytropic index for the core
+EoS_Param_Stiff = (
+    γcore = 3.0, # Polytropic index for the core
     ρb = 3e14*1e3, # Transition density between crust and core in kg/m^3
 )
-
+EoS_Param_Soft = (
+    γcore = 5.0/2.0, # Polytropic index for the core
+    ρb = 3e14*1e3, # Transition density between crust and core in kg/m^3
+)
 # Simulation Input Parameters
 Sim_Input = (
     ρ0 = 1e15*1e3, # Initial central density in kg/m^3 !! CHECKING UNITS
@@ -82,32 +85,71 @@ function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
 end
 
 # Fucntion Setup for inverse EoS and TOV equation for the solver
-EoS, EoS_inv = EoS_Func(EoS_Param, PhysConst);
+EoS_Stiff, EoS_inv_Stiff = EoS_Func(EoS_Param_Stiff, PhysConst);
+EoS_Soft, EoS_inv_Soft = EoS_Func(EoS_Param_Soft, PhysConst);
 
 # Setting up initial condition accordingly to the EoS for a given central density ρ0.
-P0 = EoS(Sim_Input.ρ0); # Initial central pressure from EoS
-m0 = 0.0; # Initial enclosed mass at the center
-u0 = [P0; m0]; # Initial conditions: central pressure and enclosed mass
+u0_Stiff = [EoS_Stiff(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure and enclosed mass
+u0_Soft = [EoS_Soft(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure and enclosed mass
 
 # Sovling the TOV equation using the RK4 method with QSpin OdeSolve module
-@time Pr, mr, ρr, r = QSpin.OdeSolve.TOV_Solve_rk4(
-    u0,
+@time Pr_Stiff, mr_Stiff, ρr_Stiff, r = QSpin.OdeSolve.TOV_Solve_rk4(
+    u0_Stiff,
     Sim_Input.dr,
     Sim_Input.Dr,
     Sim_Input.r_end,
-    EoS_inv,
+    EoS_inv_Stiff,
+    PhysConst,
+);
+
+@time Pr_Soft, mr_Soft, ρr_Soft = QSpin.OdeSolve.TOV_Solve_rk4(
+    u0_Soft,
+    Sim_Input.dr,
+    Sim_Input.Dr,
+    Sim_Input.r_end,
+    EoS_inv_Soft,
     PhysConst,
 );
 
 # Plotting
-Pc = EoS(Sim_Input.ρ0) # Check continuity at crust-core transition
-plot!(
-    r/1e3,
-    Pr/Pc,
-    label = string(L"\gamma_{core}=", EoS_Param.γcore),
-    xlabel = "Radius (km)",
-    ylabel = L"P/P_c",
-    title = string("TOV Solution for ", L"ρ_{c}=", Sim_Input.ρ0, L"\textrm{kg/m}^3"),
-    xticks = range(0.0, stop = 15.0, length = 7),
-    yticks = range(0.0, stop = 1.0, length = 6),
+Pc_Stiff = EoS_Stiff(Sim_Input.ρ0) # Check continuity at crust-core transition
+Pc_Soft = EoS_Soft(Sim_Input.ρ0) # Check continuity at crust-core transition
+
+
+plot(
+    plot(
+        r/1e3,
+        [Pr_Stiff/Pc_Stiff Pr_Soft/Pc_Soft],
+        label = [string(L"\gamma_{core}=", EoS_Param_Stiff.γcore) string(
+            L"\gamma_{core}=",
+            EoS_Param_Soft.γcore,
+        )],
+        xlabel = "Radius (km)",
+        ylabel = L"P/P_c",
+        framestyle = :box,
+    ),
+    plot(
+        r/1e3,
+        [mr_Stiff mr_Soft]/PhysConst.Msun,
+        label = [string(L"\gamma_{core}=", EoS_Param_Stiff.γcore) string(
+            L"\gamma_{core}=",
+            EoS_Param_Soft.γcore,
+        )],
+        xlabel = "Radius (m)",
+        ylabel = L"m/M_\odot",
+        framestyle = :box,
+    ),
+    plot(
+        r/1e3,
+        [ρr_Stiff ρr_Soft],
+        label = [string(L"\gamma_{core}=", EoS_Param_Stiff.γcore) string(
+            L"\gamma_{core}=",
+            EoS_Param_Soft.γcore,
+        )],
+        xlabel = "Radius (m)",
+        ylabel = L"\rho\;(\textrm{kg/m}^3)",
+        framestyle = :box,
+    ),
+    layout = (1, 3),
 )
+#plot!(size=(800,400))

--- a/scripts/tov_eq.jl
+++ b/scripts/tov_eq.jl
@@ -35,7 +35,7 @@ Set up the EoS functions for a given set of parameters and physical constants.
 - `EoS_P::Function`: The EoS function that gives pressure as a function of density.
 - `EoS_Inv::Function`: The inverse EoS function that gives density as a function of pressure.
 
-# A polytropic EoS is used in this script.
+# A polytropic EoS is used in this script according to https://github.com/vanessagraber/teaching_materials/blob/master/summerschool_CRAQ_2019/mass_radius_relations.ipynb.
 
 """
 function EoS_Func(EoS_Param::ParameterType, PhysConst::ParameterType)
@@ -95,7 +95,7 @@ EoS_Soft, EoS_inv_Soft = EoS_Func(EoS_Param_Soft, PhysConst);
 u0_Stiff = [EoS_Stiff(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure and enclosed mass
 u0_Soft = [EoS_Soft(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure and enclosed mass
 
-# Sovling the TOV equation using the RK4 method with QSpin OdeSolve module
+# Sovling the TOV equation using the RK4 method with QSpin OdeSolve module for Stiff and Soft EoSs.
 @time Pr_Stiff, mr_Stiff, ρr_Stiff, M_Stiff, R_Stiff, r = QSpin.OdeSolve.TOV_Solve_rk4(
     u0_Stiff,
     Sim_Input.dr,
@@ -114,13 +114,8 @@ u0_Soft = [EoS_Soft(Sim_Input.ρ0); 0.0]; # Initial conditions: central pressure
     PhysConst,
 );
 
-# Plotting
-Pc_Stiff = EoS_Stiff(Sim_Input.ρ0) # Check continuity at crust-core transition
-Pc_Soft = EoS_Soft(Sim_Input.ρ0) # Check continuity at crust-core transition
-
+# Computing the M-R relation by varying the central density and solving the TOV equation for each case. The radius is defined by the first point that the pressure becomes negative.
 ρc_scan = exp10.(range(17.5, stop = 20, length = 150))
-
-
 M_StiffScan = zeros(length(ρc_scan));
 R_StiffScan = zeros(length(ρc_scan));
 M_SoftScan = zeros(length(ρc_scan));
@@ -151,6 +146,9 @@ for cc = 1:length(ρc_scan)
     R_SoftScan[Int.(cc)] = R
 end
 
+# Plotting
+Pc_Stiff = EoS_Stiff(Sim_Input.ρ0) # Getting the reference core pressure for the stiff case.
+Pc_Soft = EoS_Soft(Sim_Input.ρ0) # Getting the reference core pressure for the soft case.
 plot(
     plot(
         r/1e3,
@@ -202,4 +200,3 @@ plot(
     ),
     layout = (2, 2),
 )
-#plot!(size=(800,400))

--- a/src/OdeSolve.jl
+++ b/src/OdeSolve.jl
@@ -135,4 +135,96 @@ function evolve_rk4(
     return ψall, tspan
 end
 
+
+function TOV_Solve_rk4(
+    u0::Union{AbstractArray,Array{Float64}},
+    dr::Float64,
+    Dr::Float64,
+    r_end::Float64,
+    EoS_inv::Function,
+)
+    # Physical constants in SI units
+    PhysConst = (
+        ħ = 1.0545718 * 1e-34, # m^2*kg / s
+        Msun = 1.9891 * 1e30,      # kg
+        c = 299792458,         # m / s
+        G = 6.67408 * 1e-11,   # m^3 / (kg * s^2)
+        kpc = 3.08567758 * 1e19, # m
+        eV = 1.782662 * 1e-36,  # kg
+        Gyear = 31556926 * 1e9,   # s
+        mn = 1.674927471 * 1e-27, # kg
+    )
+    """
+    Set up the TOV equation for a given inverse EoS function and physical constants.
+
+    # Arguments
+    - `EoS_inv::Function`: The inverse EoS function that gives density as
+    - 'u::AbstractArray': The current state of the system, where u[1] is pressure P and u[2] is enclosed mass m.
+    -'r::Float64': The current radius at which the TOV equation is being evaluated.
+
+    # Returns
+    - `tov_eq::Function`: A function of [dP/dr; dm/dr] for the TOV equation.
+
+    """
+    function TOV_Eq(Eos_inv::Function, PhysConst::ParameterType)
+        function tov_eq(u::AbstractArray, r::Float64)
+            P = u[1];
+            m = u[2];
+            ρ = EoS_inv(P);
+            if r == 0.0
+                dPdr = 0;
+            else
+                dPdr =
+                    -PhysConst.G / r^2 *
+                    (ρ + P/PhysConst.c^2) *
+                    (m + 4*π*r^3*P/PhysConst.c^2) / (1 - 2*PhysConst.G*m/(r*PhysConst.c^2));
+            end
+            dmdr = 4*π*r^2*ρ;
+            return [dPdr; dmdr]
+        end
+        return tov_eq
+    end
+    TOV = TOV_Eq(EoS_inv, PhysConst);
+    ΔNr = floor(Int, Dr / dr)
+    Nr = floor(Int, r_end / Dr)
+    uall = zeros(eltype(u0), size(u0)..., Nr + 1)
+    dims = ndims(u0)
+    radial_dimension_index = dims + 1
+    selectdim(uall, radial_dimension_index, 1) .= u0
+    rspan = zeros(Nr + 1)
+
+    r = 0.0
+    ucurrent = u0
+    save_number = 1
+    step_number = 0
+
+    @inbounds while r < r_end
+        ucurrent = ode_rk4(ucurrent, dr, r, TOV)
+        r += dr
+        step_number += 1
+        if sum(isnan.(ucurrent[:]))>0
+            println(
+                "NaN detected in the field at radius ",
+                r,
+                ". Radius Step could be too big.",
+            )
+            break
+        end
+        if mod(step_number, ΔNr) == 0
+            selectdim(uall, radial_dimension_index, save_number + 1) .= ucurrent
+            rspan[save_number+1] = r
+            save_number += 1
+        end
+    end
+
+    Pr = uall[1, :];
+    mr = uall[2, :];
+    ρr = zeros(length(r))
+    for rr = 1:length(r)
+        ρr[rr] = EoS_inv(Pr[rr]) # Density profile from the inverse EoS
+    end
+    return Pr, mr, ρr, rspan
+
+end
+
 end

--- a/src/OdeSolve.jl
+++ b/src/OdeSolve.jl
@@ -224,7 +224,11 @@ function TOV_Solve_rk4(
     for rr = 1:length(rspan)
         ρr[rr] = EoS_inv(Pr[rr]) # Density profile from the inverse EoS
     end
-    return Pr, mr, ρr, rspan
+
+    R_index = findfirst(x->x<0, Pr);
+    M = mr[R_index];
+    R = rspan[R_index];
+    return Pr, mr, ρr, M, R, rspan
 
 end
 

--- a/src/OdeSolve.jl
+++ b/src/OdeSolve.jl
@@ -220,8 +220,8 @@ function TOV_Solve_rk4(
 
     Pr = uall[1, :];
     mr = uall[2, :];
-    ρr = zeros(length(r))
-    for rr = 1:length(r)
+    ρr = zeros(length(rspan))
+    for rr = 1:length(rspan)
         ρr[rr] = EoS_inv(Pr[rr]) # Density profile from the inverse EoS
     end
     return Pr, mr, ρr, rspan

--- a/src/OdeSolve.jl
+++ b/src/OdeSolve.jl
@@ -142,6 +142,7 @@ function TOV_Solve_rk4(
     Dr::Float64,
     r_end::Float64,
     EoS_inv::Function,
+    PhysConst::ParameterType,
 )
     # Physical constants in SI units
     PhysConst = (

--- a/src/OdeSolve.jl
+++ b/src/OdeSolve.jl
@@ -142,19 +142,9 @@ function TOV_Solve_rk4(
     Dr::Float64,
     r_end::Float64,
     EoS_inv::Function,
-    PhysConst::ParameterType,
 )
     # Physical constants in SI units
-    PhysConst = (
-        ħ = 1.0545718 * 1e-34, # m^2*kg / s
-        Msun = 1.9891 * 1e30,      # kg
-        c = 299792458,         # m / s
-        G = 6.67408 * 1e-11,   # m^3 / (kg * s^2)
-        kpc = 3.08567758 * 1e19, # m
-        eV = 1.782662 * 1e-36,  # kg
-        Gyear = 31556926 * 1e9,   # s
-        mn = 1.674927471 * 1e-27, # kg
-    )
+
     """
     Set up the TOV equation for a given inverse EoS function and physical constants.
 
@@ -167,7 +157,17 @@ function TOV_Solve_rk4(
     - `tov_eq::Function`: A function of [dP/dr; dm/dr] for the TOV equation.
 
     """
-    function TOV_Eq(Eos_inv::Function, PhysConst::ParameterType)
+    function TOV_Eq(Eos_inv::Function)
+        PhysConst = (
+            ħ = 1.0545718 * 1e-34, # m^2*kg / s
+            Msun = 1.9891 * 1e30,      # kg
+            c = 299792458,         # m / s
+            G = 6.67408 * 1e-11,   # m^3 / (kg * s^2)
+            kpc = 3.08567758 * 1e19, # m
+            eV = 1.782662 * 1e-36,  # kg
+            Gyear = 31556926 * 1e9,   # s
+            mn = 1.674927471 * 1e-27, # kg
+        )
         function tov_eq(u::AbstractArray, r::Float64)
             P = u[1];
             m = u[2];
@@ -185,7 +185,7 @@ function TOV_Solve_rk4(
         end
         return tov_eq
     end
-    TOV = TOV_Eq(EoS_inv, PhysConst);
+    TOV = TOV_Eq(EoS_inv);
     ΔNr = floor(Int, Dr / dr)
     Nr = floor(Int, r_end / Dr)
     uall = zeros(eltype(u0), size(u0)..., Nr + 1)

--- a/src/PhysicalConstants.jl
+++ b/src/PhysicalConstants.jl
@@ -1,0 +1,46 @@
+"""
+Defines a number of fundamental physical constants for use in simulations.
+"""
+module PhysicalConstants
+
+export planck_constant,
+    hbar,
+    mass_sun,
+    speed_of_light_vacuum,
+    gravitational_constant,
+    electron_volt,
+    eV_ceq1,
+    kiloparsec_in_m,
+    neutron_mass,
+    gyr
+
+# planck constant; m^2 kg / s
+planck_constant = 6.62607015e-34
+hbar = planck_constant / (2*pi)
+
+# Mass of the sun; kg
+mass_sun = 1.9891e30
+
+# Speed of light in vacuum; m / s
+speed_of_light_vacuum = 2.99792458e8
+
+# Universal gravitational constant; m^3 / kg s^2
+gravitational_constant = 6.67408e-11
+
+# Electron volt; J
+electron_volt = 1.60218e-19
+# Electron volt in c=1 units; kg
+eV_ceq1 = electron_volt / (speed_of_light_vacuum^2)
+
+# Kiloparsec in metres; m
+kiloparsec_in_m = 3.08567758e19
+
+# Neutron mass; kg
+neutron_mass = 1.674927471e-27
+
+# Gigayear; s
+# NOTE: aren't there 10^16 seconds in a giga year?
+# 1 yr ~ 3e7 seconds, so 1 Gyr ~ 3e16 seconds?
+gyr = 3.1556926e9
+
+end

--- a/src/QSpin.jl
+++ b/src/QSpin.jl
@@ -3,6 +3,9 @@ module QSpin
 # Load ParameterType for solvers
 include("Parameters.jl")
 
+# Load physical constants that have no dependencies
+include("PhysicalConstants.jl")
+
 include("OdeSolve.jl")
 include("Grids.jl")
 include("Hamiltonian.jl")


### PR DESCRIPTION
This pull request I two scripts are added: tov_eq.jl and PhysConsts.jl. The former provides a comprehensive example on solving TOV equation according to the [example](https://github.com/vanessagraber/teaching_materials/blob/master/summerschool_CRAQ_2019/mass_radius_relations.ipynb.). The latter is just a script to generate fundamental physical parameters.

I want to blend PhysConst.jl by default, so I can call PhysConst.XX directly. Any thoughts? #35 