### PR TITLE
Add physical constants to `QSpin` package

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,7 @@
 
 ```@autodocs
 Modules = [
+  QSpin.PhysicalConstants,
   QSpin.Parameters,
   QSpin.Grids,
   QSpin.Hamiltonian,

--- a/src/PhysicalConstants.jl
+++ b/src/PhysicalConstants.jl
@@ -1,0 +1,46 @@
+"""
+Defines a number of fundamental physical constants for use in simulations.
+"""
+module PhysicalConstants
+
+export planck_constant,
+    hbar,
+    mass_sun,
+    speed_of_light_vacuum,
+    gravitational_constant,
+    electron_volt,
+    eV_ceq1,
+    kiloparsec_in_m,
+    neutron_mass,
+    gyr
+
+# planck constant; m^2 kg / s
+planck_constant = 6.62607015e-34
+hbar = planck_constant / (2*pi)
+
+# Mass of the sun; kg
+mass_sun = 1.9891e30
+
+# Speed of light in vacuum; m / s
+speed_of_light_vacuum = 2.99792458e8
+
+# Universal gravitational constant; m^3 / kg s^2
+gravitational_constant = 6.67408e-11
+
+# Electron volt; J
+electron_volt = 1.60218e-19
+# Electron volt in c=1 units; kg
+eV_ceq1 = electron_volt / (speed_of_light_vacuum^2)
+
+# Kiloparsec in metres; m
+kiloparsec_in_m = 3.08567758e19
+
+# Neutron mass; kg
+neutron_mass = 1.674927471e-27
+
+# Gigayear; s
+# NOTE: aren't there 10^16 seconds in a giga year?
+# 1 yr ~ 3e7 seconds, so 1 Gyr ~ 3e16 seconds?
+gyr = 3.1556926e9
+
+end

--- a/src/QSpin.jl
+++ b/src/QSpin.jl
@@ -3,6 +3,9 @@ module QSpin
 # Load ParameterType for solvers
 include("Parameters.jl")
 
+# Load physical constants that have no dependencies
+include("PhysicalConstants.jl")
+
 include("OdeSolve.jl")
 include("Grids.jl")
 include("Hamiltonian.jl")


### PR DESCRIPTION
Addresses #35 |

Moves the constants [defined in `PhysConst.jl`](https://github.com/NSs-FLF-RHUL/QSpin/blob/785a241f2d1ca0a668759de0ebdabc56a404b153/scripts/PhysConsts.jl) into `QSpin` itself.

Physical constants can now be accessed in scripts via

```julia
using QSpin.PhysicalConstants
```

which will populate your script's namespace with all the physical constants defined.
For example,

```julia
using QSpin.PhysicalConstants

println("Planck constant = ", planck_constant)
println("Speed of light in vacuum = ", speed_of_light_vacuum)
```

It also allows for selective importing from this module too, since in general people may not want to populate the entire namespace will all the constants.

```
using QSpin.PhysicalConstants: spped_of_light_vacuum

# Only populates the namespace with the speed_of_light_vacuum constant, and no others
```

## To check

(@ligeston make sure you're happy with these, or challenge me about why I've done them, before you merge :grin: )

- I haven't removed the `scripts/PhysConsts.jl` file since this will introduce merge conflicts with the base branch. If you're happy with these changes, I suggest we merge this into the target branch, which is #36. Then we can adapt the `tov_eq.jl` script to use the physical constants from the package in #36 itself.
- In general, I've given the constants variable names that match their actual names, rather than their common symbols. EG, `planck_constant` over `h`, `hbar` over $\bar{h}$, etc.
  - This is generally good programming practice since it makes it clearer what quantities are being used in the code itself.
  - And from a readability perspective, it is very hard to distinguish between one-letter variable names (`h` and `ħ` are particular culprits!) when reading mono-spaced fonts!
  - It is also very easy to accidentally overwrite one-letter variable names via `using`
- Please check the "seconds in a giga-year" value. I think this value is wrong in [the original file](https://github.com/NSs-FLF-RHUL/QSpin/blob/785a241f2d1ca0a668759de0ebdabc56a404b153/scripts/PhysConsts.jl#L9) and [I've updated it accordingly in this PR](https://github.com/NSs-FLF-RHUL/QSpin/blob/f5868142278349d7d00cf9d687381aa985b4ba8e/src/PhysicalConstants.jl#L44). But it could be a different physical quantity that I've misunderstood :sweat_smile: 