### PR TITLE
Simplify expression of angular momentum

### DIFF
--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -159,7 +159,10 @@ function fft_Lzψ(
     X::Array{Float64},
     Y::Array{Float64},
     Kx::Array{Float64},
-    Ky::Array{Float64},
+X::AbstractMatrix{Float64},
+Y::AbstractMatrixFloat64},
+Kx::AbstractMatrix{Float64},
+Ky::AbstractMatrix{Float64},
 )
     function angular_momentum_z(
         ψ::Union{AbstractArray,Array{Float64},Array{ComplexF64}},

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -156,9 +156,6 @@ TODO: Combine with `Pfft_Lzψ`, below.
 - `Ky::Array{Float64}`: ky-coordinate matrix.
 """
 function fft_Lzψ(
-    X::Array{Float64},
-    Y::Array{Float64},
-    Kx::Array{Float64},
     X::AbstractMatrix{Float64},
     Y::AbstractMatrix{Float64},
     Kx::AbstractMatrix{Float64},

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -159,10 +159,10 @@ function fft_Lzψ(
     X::Array{Float64},
     Y::Array{Float64},
     Kx::Array{Float64},
-X::AbstractMatrix{Float64},
-Y::AbstractMatrixFloat64},
-Kx::AbstractMatrix{Float64},
-Ky::AbstractMatrix{Float64},
+    X::AbstractMatrix{Float64},
+    Y::AbstractMatrix{Float64},
+    Kx::AbstractMatrix{Float64},
+    Ky::AbstractMatrix{Float64},
 )
     function angular_momentum_z(
         ψ::Union{AbstractArray,Array{Float64},Array{ComplexF64}},

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -167,7 +167,7 @@ function fft_Lzψ(
         time::Float64,
     )
         ψk = fft(ψ)
-        return im .* (Y .* ifft(im .* Kx .* ψk) - X .* ifft(im .* Ky .* ψk))
+        return -(Y .* ifft(Kx .* ψk) - X .* ifft(Ky .* ψk))
     end
     return angular_momentum_z
 end
@@ -208,7 +208,7 @@ function Pfft_Lzψ(
         time::Float64,
     )
         ψk = PFFT * ψ;
-        return im .* (Y .* (PiFFT * (im .* Kx .* ψk)) - X .* (PiFFT * (im .* Ky .* ψk)));
+        return -(Y .* (PiFFT * (Kx .* ψk)) - X .* (PiFFT * (Ky .* ψk)));
     end
     return angular_momentum_z
 end


### PR DESCRIPTION
This is an extremely minor optimisation, but may still be worth it.  The [Fourier transform is a linear operator](https://en.wikipedia.org/wiki/Fourier_transform#Linearity), so the imaginary units can be taken out of the transforms, factored out and multiplied directly by the outer imaginary unit.  As a concrete evidence:
```julia-repl
julia> using FFTW

julia> ψ = randn(100, 100);

julia> ψk = fft(ψ);

julia> X = randn(100, 100); Y = randn(100, 100); Kx = randn(100, 100); Ky = randn(100, 100);

julia> im .* (Y .* (ifft(im .* Kx .* ψk)) - X .* (ifft(im .* Ky .* ψk))) ≈ -(Y .* (ifft(Kx .* ψk)) - X .* (ifft(Ky .* ψk)))
true
```
The expression on the left-hand side (what's currently in the code) is the same as the expression on the right-hand side (what's proposed here).

It doesn't look like these functions are currently covered by tests though.