### PR TITLE
Use `Pfft_Lzψ` inside `fft_Lzψ`

### DIFF
--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -148,10 +148,10 @@ The returned function has signature `Lz(ψ, parameters, time)`.
 The various coordinate matrices can be obtained via the `CartGrid` function in `Grids.jl`.
 
 # Arguments
-- `X::Array{Float64}`: x-coordinate matrix.
-- `Y::Array{Float64}`: y-coordinate matrix.
-- `Kx::Array{Float64}`: kx-coordinate matrix.
-- `Ky::Array{Float64}`: ky-coordinate matrix.
+- `X::AbstractMatrix{Float64}`: x-coordinate matrix.
+- `Y::AbstractMatrix{Float64}`: y-coordinate matrix.
+- `Kx::AbstractMatrix{Float64}`: kx-coordinate matrix.
+- `Ky::AbstractMatrix{Float64}`: ky-coordinate matrix.
 """
 function fft_Lzψ(
     X::AbstractMatrix{Float64},
@@ -180,18 +180,18 @@ The various coordinate matrices can be obtained via the `CartGrid` function in `
 The plans for the forward and inverse Fourier transforms can be generated using the `plan_{i}fft` function(s) provided by `FFTW`.
 
 # Arguments
-- `X::Array{Float64}`: x-coordinate matrix.
-- `Y::Array{Float64}`: y-coordinate matrix.
-- `Kx::Array{Float64}`: kx-coordinate matrix.
-- `Ky::Array{Float64}`: ky-coordinate matrix.
+- `X::AbstractMatrix{Float64}`: x-coordinate matrix.
+- `Y::AbstractMatrix{Float64}`: y-coordinate matrix.
+- `Kx::AbstractMatrix{Float64}`: kx-coordinate matrix.
+- `Ky::AbstractMatrix{Float64}`: ky-coordinate matrix.
 - `PFFT::`: Plan for forward FFT.
 - `PiFFT::`: Plan for inverse FFT.
 """
 function Pfft_Lzψ(
-    X::Array{Float64},
-    Y::Array{Float64},
-    Kx::Array{Float64},
-    Ky::Array{Float64},
+    X::AbstractMatrix{Float64},
+    Y::AbstractMatrix{Float64},
+    Kx::AbstractMatrix{Float64},
+    Ky::AbstractMatrix{Float64},
     PFFT,
     PiFFT,
 )

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -90,7 +90,7 @@ The k-square matrix can be obtained from the `CartGrid` function in `Grids.jl`.
 The plans for the forward and inverse Fourier transforms can be generated using the `plan_{i}fft` function(s) provided by `FFTW`.
 
 # Arguments
-- `KE_mtx::AbstractMatrix`: k-square matrix for computing kinetic energy in momentum space.
+- `KE_mtx::AbstractArray`: k-square matrix for computing kinetic energy in momentum space.
     This can be obtained by using the k-matrices in `CartGrid` function in `Grids.jl`.
 - `PFFT::`: Plan for forward FFT.
 - `PiFFT::`: Plan for inverse FFT.
@@ -98,7 +98,7 @@ The plans for the forward and inverse Fourier transforms can be generated using 
 # Returns
 - `kinetic_energy::Function`: Function that evaluates the kinetic energy.
 """
-function Pfft_ke(KE_mtx::AbstractMatrix{Float64}, PFFT, PiFFT)
+function Pfft_ke(KE_mtx::AbstractArray{Float64}, PFFT, PiFFT)
     function kinetic_energy(ψ::AbstractArray, parameters::ParameterType, time::Float64)
         return PiFFT * (KE_mtx .* (PFFT * ψ))
     end
@@ -115,13 +115,13 @@ The returned function has signature `kinetic_energy(ψ, parameters, time)`.
 The k-square matrix can be obtained from the `CartGrid` function in `Grids.jl`.
 
 # Arguments
-- `KE_mtx::AbstractMatrix`: k-square matrix for computing kinetic energy in momentum space.
+- `KE_mtx::AbstractArray`: k-square matrix for computing kinetic energy in momentum space.
     This can be obtained by using the k-matrices in `CartGrid` function in `Grids.jl`.
 
 # Returns
 - `kinetic_energy::Function`: Function that evaluates the kinetic energy.
 """
-function fft_ke(KE_mtx::AbstractMatrix{Float64})
+function fft_ke(KE_mtx::AbstractArray{Float64})
     PFFT = plan_fft(KE_mtx)
     PiFFT = inv(PFFT)
 

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -90,7 +90,7 @@ The k-square matrix can be obtained from the `CartGrid` function in `Grids.jl`.
 The plans for the forward and inverse Fourier transforms can be generated using the `plan_{i}fft` function(s) provided by `FFTW`.
 
 # Arguments
-- `KE_mtx::AbstractArray`: k-square matrix for computing kinetic energy in momentum space.
+- `KE_mtx::AbstractMatrix`: k-square matrix for computing kinetic energy in momentum space.
     This can be obtained by using the k-matrices in `CartGrid` function in `Grids.jl`.
 - `PFFT::`: Plan for forward FFT.
 - `PiFFT::`: Plan for inverse FFT.
@@ -98,7 +98,7 @@ The plans for the forward and inverse Fourier transforms can be generated using 
 # Returns
 - `kinetic_energy::Function`: Function that evaluates the kinetic energy.
 """
-function Pfft_ke(KE_mtx::Array{Float64}, PFFT, PiFFT)
+function Pfft_ke(KE_mtx::AbstractMatrix{Float64}, PFFT, PiFFT)
     function kinetic_energy(ψ::AbstractArray, parameters::ParameterType, time::Float64)
         return PiFFT * (KE_mtx .* (PFFT * ψ))
     end
@@ -114,24 +114,18 @@ The returned function has signature `kinetic_energy(ψ, parameters, time)`.
 
 The k-square matrix can be obtained from the `CartGrid` function in `Grids.jl`.
 
-TODO: Combine this function with `Pfft_ke`, above.
-
 # Arguments
-- `KE_mtx::AbstractArray`: k-square matrix for computing kinetic energy in momentum space.
+- `KE_mtx::AbstractMatrix`: k-square matrix for computing kinetic energy in momentum space.
     This can be obtained by using the k-matrices in `CartGrid` function in `Grids.jl`.
 
 # Returns
 - `kinetic_energy::Function`: Function that evaluates the kinetic energy.
 """
-function fft_ke(KE_mtx::Array{Float64})
-    function kinetic_energy(
-        ψ::Union{AbstractArray,Array{Float64},Array{ComplexF64}},
-        parameters::ParameterType,
-        time::Float64,
-    )
-        return ifft(KE_mtx .* fft(ψ))
-    end
-    return kinetic_energy
+function fft_ke(KE_mtx::AbstractMatrix{Float64})
+    PFFT = plan_fft(KE_mtx)
+    PiFFT = inv(PFFT)
+
+    return Pfft_ke(KE_mtx, PFFT, PiFFT)
 end
 
 """

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -147,8 +147,6 @@ The returned function has signature `Lz(ψ, parameters, time)`.
 
 The various coordinate matrices can be obtained via the `CartGrid` function in `Grids.jl`.
 
-TODO: Combine with `Pfft_Lzψ`, below.
-
 # Arguments
 - `X::Array{Float64}`: x-coordinate matrix.
 - `Y::Array{Float64}`: y-coordinate matrix.
@@ -161,15 +159,10 @@ function fft_Lzψ(
     Kx::AbstractMatrix{Float64},
     Ky::AbstractMatrix{Float64},
 )
-    function angular_momentum_z(
-        ψ::Union{AbstractArray,Array{Float64},Array{ComplexF64}},
-        parameters::ParameterType,
-        time::Float64,
-    )
-        ψk = fft(ψ)
-        return -(Y .* ifft(Kx .* ψk) - X .* ifft(Ky .* ψk))
-    end
-    return angular_momentum_z
+
+    PFFT = plan_fft(X)
+    PiFFT = inv(PFFT)
+    return Pfft_Lzψ(X, Y, Kx, Ky, PFFT, PiFFT)
 end
 
 """


### PR DESCRIPTION
Follow up to #42, reuse functions to reduce duplication.