### PR TITLE
Fix values of many physical constants

### DIFF
--- a/src/PhysicalConstants.jl
+++ b/src/PhysicalConstants.jl
@@ -43,6 +43,7 @@ const kiloparsec_in_m = 3.08567758e19
 
 # Neutron mass; kg
 const neutron_mass = NeutronMass.val
+const atomic_mass = AtomicMassConstant.val 
 
 # Gigayear; s
 const gyr = 86400 * 365.24219 * 1e9

--- a/src/PhysicalConstants.jl
+++ b/src/PhysicalConstants.jl
@@ -8,6 +8,7 @@ using PhysicalConstants.CODATA2022:
     PlanckConstant,
     ReducedPlanckConstant,
     NeutronMass,
+    AtomicMassConstant,
     ElementaryCharge
 export planck_constant,
     hbar,
@@ -43,7 +44,7 @@ const kiloparsec_in_m = 3.08567758e19
 
 # Neutron mass; kg
 const neutron_mass = NeutronMass.val
-const atomic_mass = AtomicMassConstant.val 
+const atomic_mass = AtomicMassConstant.val
 
 # Gigayear; s
 const gyr = 86400 * 365.24219 * 1e9

--- a/src/PhysicalConstants.jl
+++ b/src/PhysicalConstants.jl
@@ -7,7 +7,8 @@ using PhysicalConstants.CODATA2022:
     SpeedOfLightInVacuum,
     PlanckConstant,
     ReducedPlanckConstant,
-    AtomicMassConstant
+    NeutronMass,
+    ElementaryCharge
 export planck_constant,
     hbar,
     mass_sun,
@@ -32,8 +33,8 @@ const speed_of_light_vacuum = SpeedOfLightInVacuum.val
 # Universal gravitational constant; m^3 / kg s^2
 const gravitational_constant = NewtonianConstantOfGravitation.val
 
-# Electron volt; J
-const electron_volt = 1.66053906892e-19
+# Electron volt; J (numerically same as elementary charge in Coulomb)
+const electron_volt = ElementaryCharge.val
 # Electron volt in c=1 units; kg
 const eV_ceq1 = electron_volt / (speed_of_light_vacuum^2)
 
@@ -41,11 +42,9 @@ const eV_ceq1 = electron_volt / (speed_of_light_vacuum^2)
 const kiloparsec_in_m = 3.08567758e19
 
 # Neutron mass; kg
-const neutron_mass = AtomicMassConstant.val
+const neutron_mass = NeutronMass.val
 
 # Gigayear; s
-# NOTE: aren't there 10^16 seconds in a giga year?
-# 1 yr ~ 3e7 seconds, so 1 Gyr ~ 3e16 seconds?
-const gyr = 3.1556926e9
+const gyr = 86400 * 365.24219 * 1e9
 
 end


### PR DESCRIPTION
Taken out of #76, this is simple enough and doesn't interact with other changes in that PR.  @ligeston note that the value of these constants were quite wrong (Gigayear was off by 7 orders of magnitude, as also pointed out by the existing comment).